### PR TITLE
Use Bytes.t for backwards compatibility

### DIFF
--- a/src/flac.ml
+++ b/src/flac.ml
@@ -228,7 +228,7 @@ struct
 
   type 'a priv
 
-  type write = bytes -> unit
+  type write = Bytes.t -> unit
 
   type 'a callbacks = 
     { 

--- a/src/flac.mli
+++ b/src/flac.mli
@@ -296,7 +296,7 @@ sig
   type 'a t
 
   (** Type of a write callback *)
-  type write = bytes -> unit
+  type write = Bytes.t -> unit
 
   (** Type of a set of callbacks *)
   type 'a callbacks


### PR DESCRIPTION
I had to make these changes to get ocaml-flac to compile on a CentOS 7 box that still comes with OCaml 4.01.