### PR TITLE
check the return when constructing comment entries

### DIFF
--- a/src/flac_stubs.c
+++ b/src/flac_stubs.c
@@ -775,11 +775,11 @@ value ocaml_flac_encoder_alloc(value comments, value params,
   /* Vendor string is ignored by libFLAC.. */
   int i;
   for (i = 0; i < Wosize_val(comments); i++) {
-    FLAC__metadata_object_vorbiscomment_entry_from_name_value_pair(
+    if (FLAC__metadata_object_vorbiscomment_entry_from_name_value_pair(
         &entry, String_val(Field(Field(comments, i), 0)),
-        String_val(Field(Field(comments, i), 1)));
-    FLAC__metadata_object_vorbiscomment_append_comment(caml_enc->meta, entry,
-                                                       true);
+        String_val(Field(Field(comments, i), 1))))
+      FLAC__metadata_object_vorbiscomment_append_comment(caml_enc->meta, entry,
+                                                         true);
   }
   FLAC__stream_encoder_set_metadata(enc, &caml_enc->meta, 1);
 


### PR DESCRIPTION
The `FLAC__metadata_object_vorbiscomment_entry_from_name_value_pair`
function call can fail which will lead to
`FLAC__metadata_object_vorbiscomment_append_comment` segfaulting or
producing invalid results. I have observed this to happen after 2 days
of normal playback. It is reproducible much more readily if I just skip
a lot.

With this fix in place, even with skipping I haven’t been able to
reproduce the crash again.